### PR TITLE
chore: configure semantic-release for 0.x.x versioning behavior

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,6 +15,8 @@
       {
         "preset": "conventionalcommits",
         "releaseRules": [
+          {"breaking": true, "release": "minor"},
+          {"type": "feat", "release": "patch"},
           {"type": "docs", "scope": "README", "release": "patch"},
           {"type": "refactor", "release": "patch"},
           {"type": "style", "release": "patch"},


### PR DESCRIPTION
## 🎯 Purpose

Configure semantic-release to handle version increments appropriately during the 0.x.x development phase, ensuring breaking changes don't prematurely bump the major version to 1.0.0.

## 📋 Changes Made

### Updated `.releaserc.json`
Added custom release rules to the `@semantic-release/commit-analyzer` configuration:

```json
"releaseRules": [
  {"breaking": true, "release": "minor"},
  {"type": "feat", "release": "patch"},
  // ... existing rules
]
```

## 🔄 New Version Increment Behavior

| Commit Type | Before | After | Example |
|-------------|--------|-------|----------|
| **Breaking changes** (`BREAKING CHANGE:` or `!`) | Major (1.0.0) | **Minor (0.X.0)** | `0.7.0` → `0.8.0` |
| **Features** (`feat:`) | Minor (0.X.0) | **Patch (0.0.X)** | `0.7.0` → `0.7.1` |
| **Fixes** (`fix:`) | Patch (0.0.X) | **Patch (0.0.X)** | `0.7.0` → `0.7.1` |
| **Major version** | Auto-increment | **Stays at 0** | Until production-ready |

## 🧪 Validation

- ✅ JSON syntax validation passed
- ✅ Semantic-release dry-run test successful
- ✅ All plugins load correctly
- ✅ Configuration follows semantic-release best practices

## 🎯 Rationale

During pre-1.0.0 development:
- **Breaking changes** should signal API instability via minor version bumps
- **Features and fixes** can both use patch increments for simplicity
- **Major version 0** indicates the project is still in active development
- **Version 1.0.0** will be reserved for the first production-ready release

This approach follows common practices for pre-1.0.0 projects and provides clear versioning signals to users about the stability and maturity of the codebase.

## 🔍 Testing

The configuration has been validated with:
```bash
npx semantic-release --dry-run --no-ci
```

Result: All plugins loaded successfully, configuration parsed correctly.

---

**Note**: This is a configuration-only change that doesn't affect the application code. The new versioning behavior will take effect on the next release after this PR is merged.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author